### PR TITLE
Implement general settings and bump version to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lanbuddy-script-parser",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,13 @@
 import * as yaml from "yaml";
 import { z } from "zod";
 
+const GeneralSchema = z.object({
+  author: z.optional(z.string()),
+  availableLanguages: z.optional(z.array(z.string())),
+  comment: z.optional(z.string()),
+  revision: z.optional(z.string()),
+});
+
 const WindowsFirewallSchema = z.object({
   action: z.enum(["allow", "block"]),
   direction: z.enum(["in", "out"]),
@@ -62,6 +69,7 @@ const StartSchema = z.object({
 
 const LaunchScriptSchema = z.object({
   game: StartSchema,
+  general: z.optional(GeneralSchema),
   server: z.optional(StartSchema),
   setup: z.optional(SetupSchema),
   version: z.literal(1),
@@ -77,6 +85,7 @@ export type StepRegistry = z.infer<typeof StepRegistrySchema>;
 export type WindowsStep = z.infer<typeof WindowsStepSchema>;
 export type Setup = z.infer<typeof SetupSchema>;
 export type Start = z.infer<typeof StartSchema>;
+export type General = z.infer<typeof GeneralSchema>;
 
 export const useLaunchScriptParser = () => {
   const parseObject = (config: object) => LaunchScriptSchema.parse(config);


### PR DESCRIPTION
This pull request includes several updates to the `lanbuddy-script-parser` package, focusing on versioning and schema enhancements. The most important changes include updating the package version, adding a new schema for general configuration, and integrating this new schema into the existing launch script schema.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `1.0.2` to `1.1.0`.

Schema enhancements:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R4-R10): Added a new `GeneralSchema` to define optional general configuration fields such as `author`, `availableLanguages`, `comment`, and `revision`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R72): Integrated the new `GeneralSchema` into the `LaunchScriptSchema` as an optional field named `general`.
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R88): Added a new type `General` inferred from the `GeneralSchema`.